### PR TITLE
Null reference exception in driver enumeration

### DIFF
--- a/iRacingSimulator/Sim.cs
+++ b/iRacingSimulator/Sim.cs
@@ -103,10 +103,11 @@ namespace iRacingSimulator
                 if (driver == null)
                 {
                     driver = Driver.FromSessionInfo(info, id);
-                    driver.IsCurrentDriver = false;
 
                     // If no driver found, end of list reached
                     if (driver == null) break;
+
+                    driver.IsCurrentDriver = false;
 
                     // Add to list
                     _drivers.Add(driver);


### PR DESCRIPTION
The driver object was updated before the null check, not after.